### PR TITLE
Fix volume increase when channel names have digits

### DIFF
--- a/pulseaudio-control.el
+++ b/pulseaudio-control.el
@@ -408,7 +408,7 @@ Amount of increase is specified by `pulseaudio-control-volume-step'."
            "\\s-+/\\s-+"
            "\\(-?\\([[:digit:]]+\\(\\.[[:digit:]]+\\)?\\)\\|-inf\\) dB"))
          (volumes-re (concat volumes-re-component
-                             "[^[:digit:]]+"
+                             "[^:]+:\\s-+"
                              volumes-re-component))
          (volumes-alist
           (progn


### PR DESCRIPTION
On my PC, the channel names for left/right speaker on one of my sinks
are named aux0 and aux1. Because of the particular construction of the
regex in `pulseaudio-control-increase-volume`, the volume string was not
parsed correctly. This commit corrects this by searching for a ":"
rather than searching for the next non-digit when parsing the second
channel's volume information.